### PR TITLE
generate_db.js: Refactor the code

### DIFF
--- a/generate-db.js
+++ b/generate-db.js
@@ -1,78 +1,71 @@
 #!/usr/bin/env node
-const fs = require("node:fs");
-const https = require("node:https");
-const path = require("node:path");
-const zlib = require("node:zlib");
+import { readFile, writeFile } from 'node:fs/promises';
+import { gunzip } from 'node:zlib';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const gunzipAsync = promisify(gunzip);
 
 // TODO(@thunder-coding): Do not hardcode list of known architectures.
 const archs = ["aarch64", "arm", "i686", "x86_64"];
-const scriptdir = process.env["TERMUX_SCRIPTDIR"];
-const prefix = process.env["TERMUX_PREFIX"];
-if (scriptdir === undefined) {
-  throw new Error("TERMUX_SCRIPTDIR environment variable is not defined");
-}
-if (prefix === undefined) {
-  throw new Error("TERMUX_PREFIX environment variable is not defined");
-}
-const binPrefix = prefix.substring(1) + "/bin/";
+const { TERMUX_SCRIPTDIR, TERMUX_PREFIX } = process.env;
 
-const repoBuffer = fs.readFileSync(path.join(scriptdir, "repo.json"));
-const repoJSON = JSON.parse(repoBuffer);
+if (!TERMUX_SCRIPTDIR) {
+  throw new Error('TERMUX_SCRIPTDIR environment variable is not defined');
+}
 
-for (const repo_path in repoJSON) {
-  if (repo_path === "pkg_format") {
-    continue;
-  }
-  const repo = repoJSON[repo_path];
+if (!TERMUX_PREFIX) {
+  throw new Error('TERMUX_PREFIX environment variable is not defined');
+}
+
+const binPrefix = TERMUX_PREFIX.substring(1) + '/bin/';
+const repos = JSON.parse(await readFile(join(TERMUX_SCRIPTDIR, 'repo.json')));
+
+async function processRepo(repo) {
   for (const arch of archs) {
-    https.get(
-      `${repo.url}/dists/${repo.distribution}/Contents-${arch}.gz`,
-      (res) => {
-        if (res.statusCode != 200) {
-          throw new Error(`${res.url} returned ${res.statusCode}`);
-        }
+    const url = `${repo.url}/dists/${repo.distribution}/Contents-${arch}.gz`;
+    const response = await fetch(url);
 
-        let rawData = [];
-        res.on("data", (chunk) => {
-          rawData.push(Buffer.from(chunk, "binary"));
-        });
-        res.on("end", () => {
-          let binMap = {};
-          let rawBuffer = Buffer.concat(rawData);
-          let ungzipped = zlib.gunzipSync(rawBuffer).toString();
-          let linesContainingPathToBinaries = ungzipped
-            .split("\n")
-            .filter((line) => {
-              return line.startsWith(binPrefix);
-            });
-          linesContainingPathToBinaries.forEach((line) => {
-            const [pathToBinary, packageNames] = line.split(" ");
-            const binary = pathToBinary.substring(
-              pathToBinary.lastIndexOf("/") + 1
-            );
-            const packages = packageNames.split(",");
+    if (!response.ok) {
+      throw new Error(`${url} returned ${response.status}`);
+    }
 
-            packages.forEach((packageName) => {
-              if (binMap[packageName] === undefined) {
-                binMap[packageName] = [];
-              }
-              binMap[packageName].push(binary);
-            });
-          });
-          const headerFile = `commands-${arch}-${repo.name}.h`;
-          if (fs.existsSync(headerFile)) {
-            fs.rmSync(headerFile);
-          }
-          Object.keys(binMap)
-            .sort()
-            .forEach((packageName) => {
-              fs.appendFileSync(headerFile, `"${packageName}",\n`);
-              binMap[packageName].sort().forEach((packageName) => {
-                fs.appendFileSync(headerFile, `" ${packageName}",\n`);
-              });
-            });
+    const data = await gunzipAsync(await response.arrayBuffer());
+    const binMap = {};
+    data
+      .toString()
+      .split('\n')
+      .filter(line => line.startsWith(binPrefix))
+      .forEach(line => {
+        const [pathToBinary, packageNames] = line.split(' ');
+        const binary = pathToBinary.substring(pathToBinary.lastIndexOf('/') + 1);
+        const packages = packageNames.split(',');
+
+        packages.forEach(packageName => {
+          binMap[packageName] ??= [];
+          binMap[packageName].push(binary);
         });
-      }
-    );
+      });
+
+    const headerFile = `commands-${arch}-${repo.name}.h`;
+    const header = Object.keys(binMap)
+      .sort()
+      .map(packageName => {
+        const binaries = binMap[packageName].sort().map(bin => `" ${bin}",`);
+        return `"${packageName}",\n${binaries.join('\n')}`;
+      })
+      .join('\n');
+
+    await writeFile(headerFile, header);
   }
 }
+
+const promises = [];
+
+for (const path in repos) {
+  if (path === 'pkg_format') continue;
+  const repo = repos[path];
+  promises.push(processRepo(repo));
+}
+
+await Promise.all(promises);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "private": true
+}


### PR DESCRIPTION
I just felt like rewriting the script to be cleaner. I switched to full async/await and ES6 modules, used the fetch API (available since Node.js 18) for the requests and overall tried to make the code look more modern.

The only downside i can think of is it's no longer parallel, I kind of made it sequential so only one network request is being done at a time, however if this is important I can very easily add that back.

I'm open to any suggestions that can improve readability.